### PR TITLE
Make XML-RPC code compatible with Erlang < R16B

### DIFF
--- a/spec/xmlrpc_codec.spec
+++ b/spec/xmlrpc_codec.spec
@@ -66,16 +66,16 @@
 	   xmlns = <<"xmlrpc">>,
 	   result = {i4, '$cdata'},
 	   cdata = #cdata{required = true,
-			  dec = {erlang, binary_to_integer, []},
-			  enc = {erlang, integer_to_binary, []}}}).
+			  dec = {xml_util, binary_to_integer, []},
+			  enc = {xml_util, integer_to_binary, []}}}).
 
 -xml(int,
      #elem{name = <<"int">>,
 	   xmlns = <<"xmlrpc">>,
 	   result = {int, '$cdata'},
 	   cdata = #cdata{required = true,
-			  dec = {erlang, binary_to_integer, []},
-			  enc = {erlang, integer_to_binary, []}}}).
+			  dec = {xml_util, binary_to_integer, []},
+			  enc = {xml_util, integer_to_binary, []}}}).
 
 -xml(string,
      #elem{name = <<"string">>,
@@ -87,8 +87,8 @@
 	   xmlns = <<"xmlrpc">>,
 	   result = {double, '$cdata'},
 	   cdata = #cdata{required = true,
-			  dec = {erlang, binary_to_float, []},
-			  enc = {erlang, float_to_binary, []}}}).
+			  dec = {xml_util, binary_to_float, []},
+			  enc = {xml_util, float_to_binary, []}}}).
 
 -xml(base64,
      #elem{name = <<"base64">>,

--- a/src/xml_util.erl
+++ b/src/xml_util.erl
@@ -1,0 +1,86 @@
+%%%----------------------------------------------------------------------
+%%% File    : xml_util.erl
+%%% Author  : Holger Weiss <holger@zedat.fu-berlin.de>
+%%% Purpose : Provide replacements for newer Erlang functions
+%%% Created : 23 Dec 2014 by Holger Weiss <holger@zedat.fu-berlin.de>
+%%%
+%%%
+%%% ejabberd, Copyright (C) 2014   ProcessOne
+%%%
+%%% This program is free software; you can redistribute it and/or
+%%% modify it under the terms of the GNU General Public License as
+%%% published by the Free Software Foundation; either version 2 of the
+%%% License, or (at your option) any later version.
+%%%
+%%% This program is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+%%% General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License along
+%%% with this program; if not, write to the Free Software Foundation, Inc.,
+%%% 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+%%%
+%%%----------------------------------------------------------------------
+
+-module(xml_util).
+-author('holger@zedat.fu-berlin.de').
+
+-export([binary_to_float/1, binary_to_integer/1, binary_to_integer/2,
+	 float_to_binary/1, integer_to_binary/1, integer_to_binary/2]).
+
+-spec(binary_to_float/1 ::
+(
+  Binary :: binary())
+    -> float()
+).
+
+binary_to_float(Binary) ->
+    list_to_float(binary_to_list(Binary)).
+
+-spec(binary_to_integer/1 ::
+(
+  Binary :: binary())
+    -> integer()
+).
+
+binary_to_integer(Binary) ->
+    list_to_integer(binary_to_list(Binary)).
+
+-spec(binary_to_integer/2 ::
+(
+  Binary :: binary(),
+  Base   :: 2..36)
+    -> integer()
+).
+
+binary_to_integer(Binary, Base) ->
+    list_to_integer(binary_to_list(Binary), Base).
+
+-spec(float_to_binary/1 ::
+(
+  Float :: float())
+    -> binary()
+).
+
+float_to_binary(Float) ->
+    list_to_binary(float_to_list(Float)).
+
+-spec(integer_to_binary/1 ::
+(
+  Integer :: integer())
+    -> binary()
+).
+
+integer_to_binary(Integer) ->
+    list_to_binary(integer_to_list(Integer)).
+
+-spec(integer_to_binary/2 ::
+(
+  Integer :: integer(),
+  Base    :: 2..36)
+    -> binary()
+).
+
+integer_to_binary(Integer, Base) ->
+    list_to_binary(integer_to_list(Integer, Base)).

--- a/src/xmlrpc_codec.erl
+++ b/src/xmlrpc_codec.erl
@@ -110,12 +110,12 @@ get_ns(_) -> <<>>.
 dec_int(Val) -> dec_int(Val, infinity, infinity).
 
 dec_int(Val, Min, Max) ->
-    case list_to_integer(binary_to_list(Val)) of
+    case xml_util:binary_to_integer(Val) of
       Int when Int =< Max, Min == infinity -> Int;
       Int when Int =< Max, Int >= Min -> Int
     end.
 
-enc_int(Int) -> list_to_binary(integer_to_list(Int)).
+enc_int(Int) -> xml_util:integer_to_binary(Int).
 
 dec_enum(Val, Enums) ->
     AtomVal = erlang:binary_to_existing_atom(Val, utf8),
@@ -476,7 +476,7 @@ decode_double_cdata(__TopXMLNS, <<>>) ->
     erlang:error({xmlrpc_codec,
 		  {missing_cdata, <<>>, <<"double">>, __TopXMLNS}});
 decode_double_cdata(__TopXMLNS, _val) ->
-    case catch erlang:binary_to_float(_val) of
+    case catch xml_util:binary_to_float(_val) of
       {'EXIT', _} ->
 	  erlang:error({xmlrpc_codec,
 			{bad_cdata_value, <<>>, <<"double">>, __TopXMLNS}});
@@ -484,7 +484,7 @@ decode_double_cdata(__TopXMLNS, _val) ->
     end.
 
 encode_double_cdata(_val, _acc) ->
-    [{xmlcdata, erlang:float_to_binary(_val)} | _acc].
+    [{xmlcdata, xml_util:float_to_binary(_val)} | _acc].
 
 decode_string(__TopXMLNS, __IgnoreEls,
 	      {xmlel, <<"string">>, _attrs, _els}) ->
@@ -539,7 +539,7 @@ decode_int_cdata(__TopXMLNS, <<>>) ->
     erlang:error({xmlrpc_codec,
 		  {missing_cdata, <<>>, <<"int">>, __TopXMLNS}});
 decode_int_cdata(__TopXMLNS, _val) ->
-    case catch erlang:binary_to_integer(_val) of
+    case catch xml_util:binary_to_integer(_val) of
       {'EXIT', _} ->
 	  erlang:error({xmlrpc_codec,
 			{bad_cdata_value, <<>>, <<"int">>, __TopXMLNS}});
@@ -547,7 +547,7 @@ decode_int_cdata(__TopXMLNS, _val) ->
     end.
 
 encode_int_cdata(_val, _acc) ->
-    [{xmlcdata, erlang:integer_to_binary(_val)} | _acc].
+    [{xmlcdata, xml_util:integer_to_binary(_val)} | _acc].
 
 decode_i4(__TopXMLNS, __IgnoreEls,
 	  {xmlel, <<"i4">>, _attrs, _els}) ->
@@ -574,7 +574,7 @@ decode_i4_cdata(__TopXMLNS, <<>>) ->
     erlang:error({xmlrpc_codec,
 		  {missing_cdata, <<>>, <<"i4">>, __TopXMLNS}});
 decode_i4_cdata(__TopXMLNS, _val) ->
-    case catch erlang:binary_to_integer(_val) of
+    case catch xml_util:binary_to_integer(_val) of
       {'EXIT', _} ->
 	  erlang:error({xmlrpc_codec,
 			{bad_cdata_value, <<>>, <<"i4">>, __TopXMLNS}});
@@ -582,7 +582,7 @@ decode_i4_cdata(__TopXMLNS, _val) ->
     end.
 
 encode_i4_cdata(_val, _acc) ->
-    [{xmlcdata, erlang:integer_to_binary(_val)} | _acc].
+    [{xmlcdata, xml_util:integer_to_binary(_val)} | _acc].
 
 decode_value(__TopXMLNS, __IgnoreEls,
 	     {xmlel, <<"value">>, _attrs, _els}) ->


### PR DESCRIPTION
This fixes `ejabberd_xmlrpc` on Erlang R15B.
