### PR TITLE
return <<>> from decode_string_cdata(__TopXMLNS, <<>>) instead of atom

### DIFF
--- a/src/xmlrpc_codec.erl
+++ b/src/xmlrpc_codec.erl
@@ -507,7 +507,7 @@ encode_string({string, Cdata}, _xmlns_attrs) ->
     _attrs = _xmlns_attrs,
     {xmlel, <<"string">>, _attrs, _els}.
 
-decode_string_cdata(__TopXMLNS, <<>>) -> undefined;
+decode_string_cdata(__TopXMLNS, <<>>) -> <<>>;
 decode_string_cdata(__TopXMLNS, _val) -> _val.
 
 encode_string_cdata(undefined, _acc) -> _acc;


### PR DESCRIPTION
return <<>> from decode_string_cdata(__TopXMLNS, <<>>) instead of atom **undefined**