### PR TITLE
Add OS-aware CFLAGS and LDFLAGS to rebar script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .rebar/
 c_src/*.o
+c_src/*.d
 config.log
 config.status
 ebin

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -35,9 +35,17 @@ FlashHackFlag = case lists:keysearch(flash_hack, 1, Cfg) of
                         ""
                 end,
 
+{OSCFlags, OSLDFlags} = case os:type() of
+			    {unix, freebsd} ->
+				{" -I/usr/local/include",
+				 " -L/usr/local/lib"};
+			    _ ->
+				{"", ""}
+			end,
+
 Config = [{erl_opts, [debug_info, {src_dirs, [src, specs]}|Macros]},
-          {port_env, [{"CFLAGS", "$CFLAGS -g -O2 -Wall" ++ FlashHackFlag},
-                      {"LDFLAGS", "$LDFLAGS -lexpat"}]},
+          {port_env, [{"CFLAGS", "$CFLAGS -g -O2 -Wall" ++ OSCFlags ++ FlashHackFlag},
+                      {"LDFLAGS", "$LDFLAGS -lexpat" ++ OSLDFlags}]},
           {port_specs, [{"priv/lib/expat_erl.so", ["c_src/expat_erl.c"]}
                         | NIFPortSpec]}],
 %%io:format("xml configuration:~n  ~p~n", [Config]),


### PR DESCRIPTION
I've added a simple case expression to rebar.config.script to find the OS type and add essential CFLAGS and LDFLAGS to compiler for building. 
For example it can solve the problem of building in FreeBSD, because of the different locations of C's **include** and **lib** directory compared to Linux's paths.

Also this is the error which I encountered before the patch:
```sh
hamidreza@freebsd: xml % ./configure 
checking for gcc... no
checking for cc... cc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether cc accepts -g... yes
checking for cc option to accept ISO C89... none needed
checking whether make sets $(MAKE)... yes
checking for an ANSI C-conforming const... yes
checking how to run the C preprocessor... cc -E
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking for stdlib.h... (cached) yes
checking for GNU libc compatible malloc... yes
checking for ANSI C header files... (cached) yes
checking for erl... /usr/local/bin/erl
checking for erlc... /usr/local/bin/erlc
checking for XML_ParserCreate in -lexpat... no
checking expat.h usability... no
checking expat.h presence... no
checking for expat.h... no
configure: error: Expat library was not found
```
