### PR TITLE
Make build fails on undefined function calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: src
 
 src:
-	rebar get-deps compile
+	rebar get-deps compile xref
 
 clean:
 	rebar clean

--- a/include/xml.hrl
+++ b/include/xml.hrl
@@ -28,6 +28,9 @@
     children = [] :: [xmlel() | cdata()]
 }).
 
+%% @type cdata() = {xmlcdata, CData}
+%%        CData = binary().
+%%  Type to hold CData (= Text) content in xmlel() data structure.
 -type(cdata() :: {xmlcdata, CData::binary()}).
 
 -type(attr() :: {Name::binary(), Value::binary()}).

--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 %%% Created :  8 May 2013 by Evgeniy Khramtsov <ekhramtsov@process-one.net>
 %%%-------------------------------------------------------------------
 
-{erl_opts, [debug_info, {src_dirs, ["src"]}]}.
+{erl_opts, [debug_info, fail_on_warning, {src_dirs, ["src"]}]}.
 {port_env, [{"CFLAGS", "$CFLAGS"}, {"LDFLAGS", "$LDFLAGS"}]}.
 {port_specs, [{"priv/lib/xml.so", ["c_src/xml.c"]},
               {"priv/lib/xml_stream.so", ["c_src/xml_stream.c"]}]}.
@@ -16,6 +16,8 @@
 
 {cover_enabled, true}.
 {cover_export_enabled, true}.
+
+{xref_checks, [undefined_function_calls, undefined_functions, deprecated_function_calls, deprecated_functions]}.
 
 {profiles, [{test, [{erl_opts, [{src_dirs, ["src", "test"]}]}]}]}.
 {plugins, [rebar3_hex]}.


### PR DESCRIPTION
This is to prevent typo in code and refactor errors.

I also added the fails on warning flag on compile to force removal of warnings in code.